### PR TITLE
Fixed typo in _OneToOneFeatureMixin

### DIFF
--- a/mamimo/carryover.py
+++ b/mamimo/carryover.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 import numpy as np
 from scipy.signal import convolve2d
-from sklearn.base import BaseEstimator, TransformerMixin, _OneToOneFeatureMixin
+from sklearn.base import BaseEstimator, TransformerMixin, OneToOneFeatureMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
@@ -16,7 +16,7 @@ from sklearn.utils.validation import (
 )
 
 
-class Carryover(_OneToOneFeatureMixin, BaseEstimator, TransformerMixin, ABC):
+class Carryover(OneToOneFeatureMixin, BaseEstimator, TransformerMixin, ABC):
     """
     Smooth the columns of an array by applying a convolution.
 

--- a/mamimo/saturation.py
+++ b/mamimo/saturation.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import List, Optional
 
 import numpy as np
-from sklearn.base import BaseEstimator, TransformerMixin, _OneToOneFeatureMixin
+from sklearn.base import BaseEstimator, TransformerMixin, OneToOneFeatureMixin
 from sklearn.utils.validation import (
     FLOAT_DTYPES,
     _check_feature_names_in,
@@ -15,7 +15,7 @@ from sklearn.utils.validation import (
 )
 
 
-class Saturation(_OneToOneFeatureMixin, BaseEstimator, TransformerMixin, ABC):
+class Saturation(OneToOneFeatureMixin, BaseEstimator, TransformerMixin, ABC):
     """Base class for all saturations, such as Box-Cox, Adbudg, ..."""
 
     def fit(self, X: np.ndarray, y: None = None) -> Saturation:


### PR DESCRIPTION
Importing several sklearn functions were failing due to typo in `_OneToOneFeatureMixin`, which is currently `OneToOneFeatureMixin` (without the underscore) in sklearn.